### PR TITLE
Oppdater luke-linker ved ny oppgave, ikke bare resize og scroll. Fixes #36

### DIFF
--- a/src/OptionsContext.tsx
+++ b/src/OptionsContext.tsx
@@ -3,9 +3,8 @@ import { Dispatch, SetStateAction, createContext, useLayoutEffect, useMemo, useS
 
 import { FCWithChildren } from "../types/utils_types"
 
-import { guardPresent } from "./utils"
+import { debug, guardPresent } from "./utils"
 import usePrefersColorScheme from "./hooks/mediaQueries/usePrefersColorScheme"
-import { getAnchorVar } from "./hooks/useStoreAnchorVars"
 
 
 const LOCALSTORAGE_KEY = "knowit_kodekalender/options"
@@ -57,8 +56,7 @@ const createScopedPersistedSetter = memoize(<K extends keyof OptionsContextSetta
       const newState = { ...state, [key]: newValue }
       const newStateJSON = JSON.stringify(pickSafeOptionsKeys(newState))
 
-      if (getAnchorVar("debug"))
-        console.log(`Setting OptionsContext localStorage state to ${newStateJSON}`)
+      debug(`Setting OptionsContext localStorage state to ${newStateJSON}`)
       localStorage.setItem(LOCALSTORAGE_KEY, newStateJSON)
 
       return newState

--- a/src/api/users/requests.ts
+++ b/src/api/users/requests.ts
@@ -5,7 +5,7 @@ import { useQueryClient, useMutation, useQuery } from "react-query"
 import { LoggedInWhoami, Whoami } from ".."
 import { QueryError } from "../../axios"
 import { EmptyObject } from "../../../types/utils_types"
-import { getAnchorVar } from "../../hooks/useStoreAnchorVars"
+import { debug } from "../../utils"
 
 
 const getWhoami = () => axios.get("/users/whoami").then(({ data }) => data)
@@ -107,10 +107,8 @@ export const useUpdateUser = () => {
   return useMutation<UpdateUserResponse, QueryError<{ errors: Record<keyof UpdateUserParameters, string[]> }>, UpdateUserParameters>(
     ["users", "udate"],
     (payload) => {
-      if (getAnchorVar("debug")) {
-        console.log("user updating:")
-        console.log({ payload })
-      }
+      debug("user updating:")
+      debug({ payload })
 
       const formData = new FormData
       forEach(payload, (value, key) => !isNil(value) && formData.append(`user[${key}]`, mapFormDataValue(value)))

--- a/src/components/users/UserForm.tsx
+++ b/src/components/users/UserForm.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../api/users/requests"
 import { QueryError } from "../../axios"
 import BasicPage from "../../pages/BasicPage"
-import { cl, squish } from "../../utils"
+import { cl, debug, squish } from "../../utils"
 import Button from "../Button"
 import CheckMark from "../checkmarks/CheckMark"
 import FormElement from "../form/FormElement"
@@ -21,9 +21,9 @@ import FormError from "../form/FormError"
 import NoteElements from "../form/NoteElements"
 import FormInputElement from "../form/FormInputElement"
 import OptInMarketingCheckboxes from "../form/OptInMarketingCheckboxes"
-import { getAnchorVar } from "../../hooks/useStoreAnchorVars"
 import FormGroup from "../form/FormGroup"
 import SubmitButton from "../SubmitButton"
+
 
 const DELETE_USER_CONFIRM = squish(`
   Er du sikker på at du vil slette brukeren din? Du vil ikke lenger være med i premietrekningen. Dette kan ikke reverseres.
@@ -107,10 +107,8 @@ const UserForm: FC<UserFormProps> = ({
   const [debouncedAvatarUrl] = useDebounce(avatarUrl, 500)
 
   const onSubmit = (data: UpdateUserParameters) => {
-    if (getAnchorVar("debug")) {
-      console.log("UserForm onSubmit")
-      console.log({ data })
-    }
+    debug("UserForm onSubmit")
+    debug({ data })
 
     submit(
       // Submit only dirty data to avoid overwriting with null values
@@ -124,9 +122,7 @@ const UserForm: FC<UserFormProps> = ({
     )
   }
 
-  if (getAnchorVar("debug")) {
-    console.log({ errors })
-  }
+  debug({ errors })
 
   const deleteUser = () => {
     if (window.confirm(DELETE_USER_CONFIRM)) {

--- a/src/hooks/useStoreAnchorVars.ts
+++ b/src/hooks/useStoreAnchorVars.ts
@@ -2,6 +2,8 @@ import { trimStart, split, filter, has, forEach } from "lodash-es"
 import { useEffect } from "react"
 import { useLocation } from "react-router-dom"
 
+import { debug } from "../utils"
+
 
 export const ANCHOR_VARS = {
   year: (s: string) => parseInt(s),
@@ -35,7 +37,7 @@ const useStoreAnchorVars = () => {
 
     forEach(validPairs, (pair) => {
       const [name, value] = split(pair, "=")
-      console.log(`Setting ${name} to ${value}`)
+      debug(`Setting ${name} to ${value}`)
       window.sessionStorage.setItem(`anchor_vars/${name}`, value)
     })
   }, [location.hash])

--- a/src/pages/Doors.tsx
+++ b/src/pages/Doors.tsx
@@ -8,7 +8,7 @@ import { ReactComponent as JulehusSvg } from "/assets/svgo/Julehus.svg"
 import { useChallenges, usePrefetchLikes, usePrefetchPosts, useSolvedStatus } from "../api/requests"
 import PageContent from "../components/PageContent"
 import { Maybe } from "../../types/utils_types"
-import { Z_JULEHUS, cl } from "../utils"
+import { Z_JULEHUS, cl, debug } from "../utils"
 import { getAnchorVar } from "../hooks/useStoreAnchorVars"
 
 
@@ -59,10 +59,10 @@ const Doors = () => {
     forEach(windowGroups, ([from, to]) => {
       const subState = slice(doorsState, from - 1, to - 1)
       if (every(subState, (state) => state === "solved")) {
-        console.log(`Setting vindu ${to - 1} to ON: ${JSON.stringify(subState)}`)
+        debug(`Setting vindu ${to - 1} to ON: ${JSON.stringify(subState)}`)
         rootStyle.setProperty(`--vindu-${to - 1}-display`, "initial")
       } else {
-        console.log(`Setting vindu ${to - 1} to OFF ${JSON.stringify(subState)}`)
+        debug(`Setting vindu ${to - 1} to OFF ${JSON.stringify(subState)}`)
         rootStyle.setProperty(`--vindu-${to - 1}-display`, "none")
       }
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,3 +209,6 @@ export const Z_HEADER = "z-[1]"
 export const Z_FOOTER = "z-[1]"
 export const Z_DROPDOWN = "z-[9]"
 export const Z_MODAL = "z-[10]"
+
+
+export const debug = (...args: Parameters<typeof console.log>) => getAnchorVar("debug") && console.log(...args)


### PR DESCRIPTION
Vurdere å bruke `console.debug` heller. Men da samsvarer det ikke med anchor var.