### PR TITLE
Replaces Checkmark animation with native SVG animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "axios": "^1.6.2",
     "clsx": "^2.0.0",
     "date-fns": "^2.23.0",
-    "framer-motion": "^10.16.5",
     "lodash-es": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/SubscribeButton.tsx
+++ b/src/components/SubscribeButton.tsx
@@ -58,7 +58,7 @@ const SubscribeButton: FC<SubscribeButtonProps> = ({ door, post, className }) =>
       className={cl(
         "origin-top transition-transform hover:-rotate-12",
         className,
-        animating && "animate-bellClick"
+        animating && "animate-bell-click"
       )}
       title={buttonTitle}
       aria-label={buttonTitle}

--- a/src/components/SubscribeButton.tsx
+++ b/src/components/SubscribeButton.tsx
@@ -1,15 +1,10 @@
-import { motion, useAnimation } from "framer-motion"
 import { find } from "lodash-es"
 import { FC, useMemo, useState } from "react"
 import { FaBellSlash, FaBell } from "react-icons/fa"
 import { useDebounce } from "use-debounce"
 
 import { ParentPost } from "../api"
-import {
-  useCreateSubscription,
-  useDeleteSubscription,
-  useSubscriptions
-} from "../api/requests"
+import { useCreateSubscription, useDeleteSubscription, useSubscriptions } from "../api/requests"
 import { cl } from "../utils"
 
 type SubscribeButtonProps = {
@@ -20,22 +15,14 @@ type SubscribeButtonProps = {
 
 const ANIMATION_DURATION = 700
 
-const SubscribeButton: FC<SubscribeButtonProps> = ({
-  door,
-  post,
-  className
-}) => {
+const SubscribeButton: FC<SubscribeButtonProps> = ({ door, post, className }) => {
   const { data: subscriptions } = useSubscriptions()
   const { mutate: createSubscription } = useCreateSubscription()
   const { mutate: deleteSubscription } = useDeleteSubscription()
 
-  const animationControl = useAnimation()
   const [animating, setAnimating] = useState(false)
 
-  const subscription = find(
-    subscriptions,
-    door ? { door } : { postUuid: post?.uuid }
-  )
+  const subscription = find(subscriptions, door ? { door } : { postUuid: post?.uuid })
   const [debouncedSubscription] = useDebounce(subscription, ANIMATION_DURATION)
 
   const buttonTitle = useMemo(() => {
@@ -62,28 +49,23 @@ const SubscribeButton: FC<SubscribeButtonProps> = ({
     else subscribe()
 
     setAnimating(true)
-    animationControl.start({
-      rotate: [-30, 20, -10, 7, -3, 0],
-      transition: { ease: "easeIn", duration: ANIMATION_DURATION / 1000 }
-    })
 
     setTimeout(() => setAnimating(false), ANIMATION_DURATION)
   }
 
   return (
-    <motion.button
-      // TODO: Hover style
-      className={cl("", className)}
+    <button
+      className={cl(
+        "origin-top transition-transform hover:-rotate-12",
+        className,
+        animating && "animate-bellClick"
+      )}
       title={buttonTitle}
       aria-label={buttonTitle}
       onClick={onClick}
-      onMouseEnter={() => animationControl.start({ rotate: -10 })}
-      onMouseLeave={() => !animating && animationControl.start({ rotate: 0 })}
     >
-      <motion.div className="origin-top" animate={animationControl}>
-        {debouncedSubscription ? <FaBellSlash /> : <FaBell />}
-      </motion.div>
-    </motion.button>
+      {debouncedSubscription ? <FaBellSlash /> : <FaBell />}
+    </button>
   )
 }
 

--- a/src/components/checkmarks/CheckMark.tsx
+++ b/src/components/checkmarks/CheckMark.tsx
@@ -1,5 +1,5 @@
+import { join } from "lodash-es"
 import { FC } from "react"
-import { motion } from "framer-motion"
 
 import { easeInOutCubic, easeOutCubic } from "../../utils"
 
@@ -12,7 +12,7 @@ const R = 62.1
 export const CheckMark: FC<CheckmarkWrapperProps> = (props) => (
   <Wrapper {...props}>
     <svg className="text-green-600 stroke-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
-      <motion.path
+      <path
         d={`
           M ${OFFSET} ${OFFSET}
           m 0 ${-R}
@@ -23,11 +23,21 @@ export const CheckMark: FC<CheckmarkWrapperProps> = (props) => (
         strokeLinecap="round"
         strokeMiterlimit="10"
         strokeWidth="6"
-        initial={{ pathLength: 0 }}
-        animate={{ pathLength: 1 }}
-        transition={{ duration: 0.4, ease: easeOutCubic }}
-      />
-      <motion.path
+        strokeDasharray="1"
+        strokeDashoffset="1"
+        pathLength="1"
+      >
+        <animate
+          attributeName="stroke-dashoffset"
+          dur=".4s"
+          by="1"
+          fill="freeze"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines={join(easeOutCubic, " ")}
+        />
+      </path>
+      <path
         d={`
           M ${OFFSET} ${OFFSET}
           m -35.3 2.4
@@ -37,10 +47,21 @@ export const CheckMark: FC<CheckmarkWrapperProps> = (props) => (
         strokeLinecap="round"
         strokeMiterlimit="10"
         strokeWidth="6"
-        initial={{ pathLength: 0 }}
-        animate={{ pathLength: 1 }}
-        transition={{ duration: 0.4, delay: 0.2, ease: easeInOutCubic }}
-      />
+        strokeDasharray="1"
+        strokeDashoffset="1"
+        pathLength="1"
+      >
+        <animate
+          attributeName="stroke-dashoffset"
+          begin=".2s"
+          dur=".4s"
+          by="-1"
+          fill="freeze"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines={join(easeInOutCubic, " ")}
+        />
+      </path>
     </svg>
   </Wrapper>
 )

--- a/src/components/checkmarks/WaitMark.tsx
+++ b/src/components/checkmarks/WaitMark.tsx
@@ -1,7 +1,7 @@
+import { join } from "lodash-es"
 import { FC, useEffect, useState } from "react"
-import { motion, useAnimation } from "framer-motion"
 
-import { cl, easeInCubic } from "../../utils"
+import { cl, easeOutCubic } from "../../utils"
 
 import Wrapper, { CheckmarkWrapperProps } from "./CheckmarkWrapper"
 
@@ -9,9 +9,8 @@ import Wrapper, { CheckmarkWrapperProps } from "./CheckmarkWrapper"
 const OFFSET = 65.1
 const R = 62.1
 
-export const WaitMark: FC<CheckmarkWrapperProps &  { retryAfter: number, className: string }> = ({ retryAfter, className, ...props }) => {
+export const WaitMark: FC<CheckmarkWrapperProps &  { retryAfter: number, className?: string }> = ({ retryAfter, className, ...props }) => {
   const [countdown, setCountdown] = useState(retryAfter)
-  const circleControls = useAnimation()
 
   useEffect(() => {
     const interval = setInterval(() => setCountdown((x) => x > 0 ? x - 1 : x), 1000)
@@ -19,17 +18,10 @@ export const WaitMark: FC<CheckmarkWrapperProps &  { retryAfter: number, classNa
     return () => clearInterval(interval)
   }, [setCountdown])
 
-  useEffect(() => {
-    circleControls.start({
-      pathLength: (countdown - 1) / retryAfter,
-      transition: { duration: 1, ease: "linear" }
-    })
-  }, [countdown, retryAfter, circleControls])
-
   return (
     <Wrapper {...props}>
       <svg className={cl("text-yellow-400 stroke-current mx-auto", className)} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
-        <motion.path
+        <path
           d={`
             M ${OFFSET} ${OFFSET}
             m 0 ${-R}
@@ -40,10 +32,18 @@ export const WaitMark: FC<CheckmarkWrapperProps &  { retryAfter: number, classNa
           strokeLinecap="round"
           strokeMiterlimit="10"
           strokeWidth="6"
-          animate={circleControls}
-          initial={{ pathLength: 1 }}
-        />
-        <motion.path
+          strokeDasharray="1"
+          strokeDashoffset="0"
+          pathLength="1"
+        >
+          <animate
+            attributeName="stroke-dashoffset"
+            dur={retryAfter}
+            by="1"
+            additive="sum"
+          />
+        </path>
+        <path
           d={`
             M ${OFFSET} ${OFFSET}
             m -15.7 -27.2
@@ -53,11 +53,22 @@ export const WaitMark: FC<CheckmarkWrapperProps &  { retryAfter: number, classNa
           strokeLinecap="round"
           strokeMiterlimit="10"
           strokeWidth="6"
-          initial={{ pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ duration: 0.2, delay: 0.4, ease: easeInCubic }}
-        />
-        <motion.path
+          strokeDasharray="1"
+          strokeDashoffset="1"
+          pathLength="1"
+        >
+          <animate
+            attributeName="stroke-dashoffset"
+            begin=".2s"
+            dur=".2s"
+            by="-1"
+            fill="freeze"
+            calcMode="spline"
+            keyTimes="0;1"
+            keySplines={join(easeOutCubic, " ")}
+          />
+        </path>
+        <path
           d={`
             M ${OFFSET} ${OFFSET}
             m 15.7 -27.2
@@ -67,10 +78,21 @@ export const WaitMark: FC<CheckmarkWrapperProps &  { retryAfter: number, classNa
           strokeLinecap="round"
           strokeMiterlimit="10"
           strokeWidth="6"
-          initial={{ pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ duration: 0.2, delay: 0.2, ease: easeInCubic }}
-        />
+          strokeDasharray="1"
+          strokeDashoffset="1"
+          pathLength="1"
+        >
+          <animate
+            attributeName="stroke-dashoffset"
+            begin=".4s"
+            dur=".2s"
+            by="-1"
+            fill="freeze"
+            calcMode="spline"
+            keyTimes="0;1"
+            keySplines={join(easeOutCubic, " ")}
+          />
+        </path>
       </svg>
       <p className="text-center mt-2">
         {countdown} sekund{countdown !== 1 && "er"}

--- a/src/components/checkmarks/WrongMark.tsx
+++ b/src/components/checkmarks/WrongMark.tsx
@@ -1,5 +1,5 @@
+import { join } from "lodash-es"
 import { FC } from "react"
-import { motion } from "framer-motion"
 
 import { easeInCubic, easeOutCubic } from "../../utils"
 
@@ -12,7 +12,7 @@ const R = 62.1
 export const WrongMark: FC<CheckmarkWrapperProps> = (props) => (
   <Wrapper {...props}>
     <svg className="text-red-700 stroke-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130.2 130.2">
-      <motion.path
+      <path
         d={`
           M ${OFFSET} ${OFFSET}
           m 0 ${-R}
@@ -23,25 +23,21 @@ export const WrongMark: FC<CheckmarkWrapperProps> = (props) => (
         strokeLinecap="round"
         strokeMiterlimit="10"
         strokeWidth="6"
-        initial={{ pathLength: 0 }}
-        animate={{ pathLength: 1 }}
-        transition={{ duration: 0.4, ease: easeOutCubic }}
-      />
-      <motion.path
-        d={`
-          M ${OFFSET} ${OFFSET}
-          m -30.7 -27.2
-          l 61.4 54.4
-        `}
-        fill="none"
-        strokeLinecap="round"
-        strokeMiterlimit="10"
-        strokeWidth="6"
-        initial={{ pathLength: 0 }}
-        animate={{ pathLength: 1 }}
-        transition={{ duration: 0.2, delay: 0.4, ease: easeInCubic }}
-      />
-      <motion.path
+        strokeDasharray="1"
+        strokeDashoffset="1"
+        pathLength="1"
+      >
+        <animate
+          attributeName="stroke-dashoffset"
+          dur=".4s"
+          by="1"
+          fill="freeze"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines={join(easeOutCubic, " ")}
+        />
+      </path>
+      <path
         d={`
           M ${OFFSET} ${OFFSET}
           m 30.7 -27.2
@@ -51,10 +47,46 @@ export const WrongMark: FC<CheckmarkWrapperProps> = (props) => (
         strokeLinecap="round"
         strokeMiterlimit="10"
         strokeWidth="6"
-        initial={{ pathLength: 0 }}
-        animate={{ pathLength: 1 }}
-        transition={{ duration: 0.2, delay: 0.2, ease: easeInCubic }}
-      />
+        strokeDasharray="1"
+        strokeDashoffset="1"
+        pathLength="1"
+      >
+        <animate
+          attributeName="stroke-dashoffset"
+          begin=".2s"
+          dur=".2s"
+          by="-1"
+          fill="freeze"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines={join(easeInCubic, " ")}
+        />
+      </path>
+      <path
+        d={`
+          M ${OFFSET} ${OFFSET}
+          m -30.7 -27.2
+          l 61.4 54.4
+        `}
+        fill="none"
+        strokeLinecap="round"
+        strokeMiterlimit="10"
+        strokeWidth="6"
+        strokeDasharray="1"
+        strokeDashoffset="1"
+        pathLength="1"
+      >
+        <animate
+          attributeName="stroke-dashoffset"
+          begin=".4s"
+          dur=".2s"
+          by="-1"
+          fill="freeze"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines={join(easeInCubic, " ")}
+        />
+      </path>
     </svg>
   </Wrapper>
 )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -106,7 +106,7 @@ export default {
         }
       },
       keyframes: {
-        bellClick: {
+        'bell-click': {
           "0%": { transform: "rotate(30deg)" },
           "20%": { transform: "rotate(-20deg)" },
           "40%": { transform: "rotate(10deg)" },
@@ -116,7 +116,7 @@ export default {
         }
       },
       animation: {
-        bellClick: "bellClick 0.7s ease-in-out"
+        'bell-click': "bell-click 0.7s ease-in-out"
       }
     }
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -104,6 +104,19 @@ export default {
             // '--tw-prose-td-borders': theme('colors.pink[200]'),
           }
         }
+      },
+      keyframes: {
+        bellClick: {
+          "0%": { transform: "rotate(30deg)" },
+          "20%": { transform: "rotate(-20deg)" },
+          "40%": { transform: "rotate(10deg)" },
+          "60%": { transform: "rotate(-7deg)" },
+          "80%": { transform: "rotate(3deg)" },
+          "100%": { transform: "rotate(0deg)" }
+        }
+      },
+      animation: {
+        bellClick: "bellClick 0.7s ease-in-out"
       }
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,13 +40,5 @@ export default defineConfig({
   },
   build: {
     chunkSizeWarningLimit: 4096,
-    rollupOptions: {
-      output: {
-        manualChunks: (id) => {
-          if (id.includes("framer-motion"))
-            return "framer-motion"
-        }
-      }
-    }
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,18 +1067,6 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@emotion/is-prop-valid@^0.8.2":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
-  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
-  dependencies:
-    "@emotion/memoize" "0.7.4"
-
-"@emotion/memoize@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
-  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
-
 "@esbuild/android-arm64@0.19.5":
   version "0.19.5"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.19.5.tgz#276c5f99604054d3dbb733577e09adae944baa90"
@@ -2968,15 +2956,6 @@ fraction.js@^4.3.6:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
-
-framer-motion@^10.16.5:
-  version "10.16.5"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-10.16.5.tgz#f1ad625adf213a8906f1ea52a31a4ef222f056d5"
-  integrity sha512-GEzVjOYP2MIpV9bT/GbhcsBNoImG3/2X3O/xVNWmktkv9MdJ7P/44zELm/7Fjb+O3v39SmKFnoDQB32giThzpg==
-  dependencies:
-    tslib "^2.4.0"
-  optionalDependencies:
-    "@emotion/is-prop-valid" "^0.8.2"
 
 fs-extra@^11.0.0:
   version "11.1.1"
@@ -4955,7 +4934,7 @@ tsconfig-paths@^3.14.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.3, tslib@^2.4.0:
+tslib@^2.0.3:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
Tenkte bare putte denne et sted. Var relativt trivielt å erstatte framer-motion animasjon med native animasjon. Var ganske enkelt med `<animate>` for checkmarks, men var en smule mer komplisert å animere vilkårlige elementer som ikoner, siden animasjonselementet må ligge _inni_ SVG-en.

Så kanskje CSS-animasjon for subscribe button? Og kanskje like button? Eller bare drite i det? Luksusfeature uansett, men jeg synes det er kos.